### PR TITLE
Use the 6.c version of lines()

### DIFF
--- a/Preface/find_moth_genera.p6
+++ b/Preface/find_moth_genera.p6
@@ -1,5 +1,7 @@
 #!perl6
 
+use v6.c;
+
 =begin pod
 
 https://github.com/briandfoy/LearningPerl6_Downloads


### PR DESCRIPTION
The lines() function changed in Perl 6.d. See https://perl6.online/2018/12/24/reading-file-contents-with-argfiles-in-perl-6/ for details. This pull request inserts "use v6.c" into Preface/find_moth_genera.p6 in order to make the program work with Rakudo 2018.12.